### PR TITLE
Remove "moj-tag--bright-red"

### DIFF
--- a/app/views/components/tag/README.md
+++ b/app/views/components/tag/README.md
@@ -53,24 +53,12 @@ There are a number of additional colour styles that can be used:
         <tr class="govuk-table__row">
             <td class="govuk-table__cell">
                 <code>
-                    moj-tag--bright-red
-                </code>
-            </td>
-            <td class="govuk-table__cell">
-                <strong aria-label="Lorem ipsum 4" class="govuk-tag moj-tag--bright-red" title="Lorem ipsum 4">
-                    Lorem ipsum 4
-                </strong>
-            </td>
-        </tr>
-        <tr class="govuk-table__row">
-            <td class="govuk-table__cell">
-                <code>
                     moj-tag--green
                 </code>
             </td>
             <td class="govuk-table__cell">
-                <strong aria-label="Lorem ipsum 5" class="govuk-tag moj-tag--green" title="Lorem ipsum 5">
-                    Lorem ipsum 5
+                <strong aria-label="Lorem ipsum 4" class="govuk-tag moj-tag--green" title="Lorem ipsum 5">
+                    Lorem ipsum 4
                 </strong>
             </td>
         </tr>
@@ -81,8 +69,8 @@ There are a number of additional colour styles that can be used:
                 </code>
             </td>
             <td class="govuk-table__cell">
-                <strong aria-label="Lorem ipsum 6" class="govuk-tag moj-tag--blue" title="Lorem ipsum 6">
-                    Lorem ipsum 6
+                <strong aria-label="Lorem ipsum 5" class="govuk-tag moj-tag--blue" title="Lorem ipsum 6">
+                    Lorem ipsum 5
                 </strong>
             </td>
         </tr> -->
@@ -93,8 +81,8 @@ There are a number of additional colour styles that can be used:
                 </code>
             </td>
             <td class="govuk-table__cell">
-                <strong aria-label="Lorem ipsum 7" class="govuk-tag moj-tag--black" title="Lorem ipsum 7">
-                    Lorem ipsum 7
+                <strong aria-label="Lorem ipsum 6" class="govuk-tag moj-tag--black" title="Lorem ipsum 7">
+                    Lorem ipsum 6
                 </strong>
             </td>
         </tr>
@@ -105,8 +93,8 @@ There are a number of additional colour styles that can be used:
                 </code>
             </td>
             <td class="govuk-table__cell">
-                <strong aria-label="Lorem ipsum 8" class="govuk-tag moj-tag--grey" title="Lorem ipsum 8">
-                    Lorem ipsum 8
+                <strong aria-label="Lorem ipsum 7" class="govuk-tag moj-tag--grey" title="Lorem ipsum 8">
+                    Lorem ipsum 7
                 </strong>
             </td>
         </tr>


### PR DESCRIPTION
### Description of the change

I spotted that the `moj-tag--bright-red` class was showing up in blue, rather than bright red:
<img width="811" alt="image" src="https://user-images.githubusercontent.com/100852/65437296-7599ae80-de1b-11e9-9893-ae69d1865f95.png">

It turns out there isn't a `moj-tag--bright-red` class in the design system, so I removed the example of it and updated the numbers in the examples so they didn't skip 4.

I presume it was removed from the design system when the colour was [dropped from the GOV.UK Design System](https://github.com/alphagov/govuk-frontend/releases/tag/v3.0.0)

### Release notes

N/A