### PR TITLE
Fix email typo

### DIFF
--- a/app/views/get-in-touch.html
+++ b/app/views/get-in-touch.html
@@ -20,7 +20,7 @@
 
 
       ## Email
-      Email the Design System team on [design-sytem@digital.justice.gov.uk](mailto:design-sytem@digital.justice.gov.uk)
+      Email the Design System team on [design-system@digital.justice.gov.uk](mailto:design-system@digital.justice.gov.uk)
      {% endmarkdown %}
     </div>
 


### PR DESCRIPTION
### Description of the change

Fix typo in email address: `design-sytem` => `design-system`

### Release notes

Not applicable