### PR TITLE
Update Slack links

### DIFF
--- a/app/views/get-in-touch.html
+++ b/app/views/get-in-touch.html
@@ -15,7 +15,7 @@
 
       ## Slack
 
-      - On the MOJ Digital &amp; Technology Slack use [#moj-design-system](https://mojdt.slack.com/messages/moj-design-system)
+      - On the MOJ Digital &amp; Technology Slack use [#moj-design-system-support](https://mojdt.slack.com/messages/moj-design-system-support)
       - On the cross-Government Slack [#moj-design-system](https://ukgovernmentdigital.slack.com/messages/moj-design-system)
 
 

--- a/app/views/get-started/deploying-your-prototype/README.md
+++ b/app/views/get-started/deploying-your-prototype/README.md
@@ -6,7 +6,7 @@ After following this guide your prototype will automatically deploy any changes 
 
 You'll need to be a member of the [moj-design](https://dashboard.heroku.com/teams/moj-design/apps) Heroku team and have your prototype in [MOJ's GitHub account](https://github.com/ministryofjustice).
 
-If you don't have access to these, ask in the Slack channel [#moj-design-system](https://mojdt.slack.com/messages/CH5RUSB27) and whoever is managing support that day should be able to add you.
+If you don't have access to these, ask in the Slack channel [#moj-design-system-support](https://mojdt.slack.com/messages/moj-design-system-support) and whoever is managing support that day should be able to add you.
 
 <!-- If you don't know how to setup GitHub read the [version your prototype](#) guide. -->
 

--- a/app/views/layouts/partials/contact-panel.html
+++ b/app/views/layouts/partials/contact-panel.html
@@ -1,5 +1,5 @@
 {{ appPanel({
     titleText: "Get in touch",
-    html: "If you’ve got a question, idea or suggestion share it on the <a class='app-panel__link' href='https://ukgovernmentdigital.slack.com/messages/moj-design-system' title='MOJ Design System channel on Slack'>#moj-design-system</a> channel on Slack or email the Design System team on <a class='app-panel__link' href='mailto:design-system@digital.justice.gov.uk'>design-system@digital.justice.gov.uk</a>"
+    html: "If you’ve got a question, idea or suggestion share it on the <a class='app-panel__link' href='https://mojdt.slack.com/messages/moj-design-system-support' title='MOJ Design System channel on Slack'>#moj-design-system-support</a> channel on Slack or email the Design System team on <a class='app-panel__link' href='mailto:design-system@digital.justice.gov.uk'>design-system@digital.justice.gov.uk</a>"
   })
 }}


### PR DESCRIPTION
### Description of the change

Update references to the MOJ channel: it's now #moj-design-system-support

Make the default suggestion the MOJ channel (rather than X-Gov): it's more active, more relevant and has a full archive

### Release notes

- Update Slack links