### PR TITLE
Add warnings to promoted components

### DIFF
--- a/app/views/components/banner/index.html
+++ b/app/views/components/banner/index.html
@@ -17,6 +17,19 @@
     text: 'experimental'
   }) }}
 
+  {% set html %}
+    <h3 class="govuk-notification-banner__heading">
+      The GOV.UK Design System has a similar component
+    </h3>
+    <p class="govuk-body">The <a href="https://design-system.service.gov.uk/components/notification-banner/">Notification banner component</a> in the GOV.UK Design System has a similar function and visual design to this component.</p>
+    <p class="govuk-body">You should consider using the GOV.UK version if it fits your needs.</p>
+  {% endset %}
+
+
+  {{ govukNotificationBanner({
+    html: html
+  }) }}
+
   <div class="app-prose-scope">
     {% markdown %}{% include "./README.md" %}{% endmarkdown %}
   </div>

--- a/app/views/components/currency-input/index.html
+++ b/app/views/components/currency-input/index.html
@@ -17,6 +17,19 @@
     text: 'experimental'
   }) }}
 
+  {% set html %}
+    <h3 class="govuk-notification-banner__heading">
+      The GOV.UK Design System has a similar component
+    </h3>
+    <p class="govuk-body">The <a href="https://design-system.service.gov.uk/components/text-input/">Text input component</a> in the GOV.UK Design System supports <a href="https://design-system.service.gov.uk/components/text-input/#prefixes-and-suffixes">prefixes and suffixes</a>, including currency symbols.</p>
+    <p class="govuk-body">You should use the GOV.UK version if you can.</p>
+  {% endset %}
+
+
+  {{ govukNotificationBanner({
+    html: html
+  }) }}
+
   <div class="app-prose-scope">
     {% markdown %}{% include "./README.md" %}{% endmarkdown %}
   </div>

--- a/app/views/layouts/base.html
+++ b/app/views/layouts/base.html
@@ -1,3 +1,4 @@
+{%- from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner -%}
 {%- from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner -%}
 {%- from "govuk/components/tag/macro.njk" import govukTag -%}
 {%- from "govuk/components/table/macro.njk" import govukTable -%}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3002,9 +3002,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.0.0.tgz",
-      "integrity": "sha512-GCrEeaQZEnsthNtfmOUFlgsieNjHOeoamSWMdD4Gdq0RPxCA9uzfrT2i3jVnlBORekKjOL0C8eFZQBSNnjtz2A=="
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.11.0.tgz",
+      "integrity": "sha512-1hW/3etYBtKPM+PNdWVOijvWVI3mpYL8eb7WLTtlh/Qxf2mCp6LkCsZk9I034n4EJBYQ5jlUWsUlTOOIypftpg=="
     },
     "graceful-fs": {
       "version": "4.1.15",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "dotenv": "^6.0.0",
     "express": "^4.16.3",
     "express-session": "^1.16.2",
-    "govuk-frontend": "^3.0.0",
+    "govuk-frontend": "^3.11.0",
     "gray-matter": "^4.0.1",
     "gulp": "^4.0.0",
     "gulp-nodemon": "^2.4.2",


### PR DESCRIPTION
The banner and currency input components can now be supported natively by the GOV.UK Design System, and users should prefer those.

This PR adds warnings to the documentation pages to nudge users towards the GDS versions.

<img width="801" alt="imagen" src="https://user-images.githubusercontent.com/100852/108530483-8f1f7e00-72cd-11eb-8b4d-195120a129ae.png">
<img width="801" alt="imagen" src="https://user-images.githubusercontent.com/100852/108530510-95155f00-72cd-11eb-8290-6d86b88d41b6.png">

Fixes #45 and #47