### PR TITLE
Update prototype docs to mention cloud platform

### DIFF
--- a/app/views/get-started/deploying-your-prototype/README.md
+++ b/app/views/get-started/deploying-your-prototype/README.md
@@ -1,8 +1,20 @@
-This guide explains how to deploy prototypes to MOJ's Heroku account.
+This guide explains how to deploy prototypes to MOJ Cloud Platform or Heroku.
 
 After following this guide your prototype will automatically deploy any changes that you push to GitHub.
 
-## Before you start
+## Deploying to MOJ Cloud Platform
+
+If you work for the Ministry of Justice, we recommend using MOJ Cloud Platform to deploy your prototype.
+
+The [Cloud Platform guide](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/prototype-kit.html) shows you how to set up a GitHub repository with the prototype kit installed, along with a Cloud Platform hosting environment. Changes to your repository will automatically be deployed to Cloud Platform.
+
+If you have any further questions, ask in the [#ask-cloud-platform](https://mojdt.slack.com/messages/ask-cloud-platform) Slack channel.
+
+## Deploying to Heroku
+
+You can also use Heroku to host your prototypes. This is recommended for staff outside the Ministry of Justice or those supporting older prototypes which are already hosted on Heroku.
+
+### Before you start
 
 You'll need to be a member of the [moj-design](https://dashboard.heroku.com/teams/moj-design/apps) Heroku team and have your prototype in [MOJ's GitHub account](https://github.com/ministryofjustice).
 
@@ -10,7 +22,7 @@ If you don't have access to these, ask in the Slack channel [#moj-design-system-
 
 <!-- If you don't know how to setup GitHub read the [version your prototype](#) guide. -->
 
-## Setting up Heroku
+### Setting up Heroku
 
 We use pipelines in Heroku. Pipelines let you have multiple apps and keep things together in one place.
 
@@ -24,7 +36,7 @@ We use pipelines in Heroku. Pipelines let you have multiple apps and keep things
 
 If everything has worked you should be taken to the pipeline view. You then need to create an app to deploy your prototype to.
 
-## Creating an app
+### Creating an app
 
 From the pipeline view.
 
@@ -40,7 +52,7 @@ You can check that the app has been deployed by selecting 'Open app'.
 
 You should see a screen saying 'Error: Username or password not set. See guidance for setting these.' instead of your prototype. Now follow the guidance on setting a username and password for your app.
 
-## Setting a username and password
+### Setting a username and password
 
 Prototypes require a username and password when published online. This stops members of the public coming across your prototype by accident.
 
@@ -56,7 +68,7 @@ You can now navigate back to the pipeline and open the app in a browser to test 
 
 If this has worked you should see a modal dialogue asking for a username and password.
 
-## Deploying your prototype
+### Deploying your prototype
 
 1. from the pipeline view app in production click the small dropdown icon within the tile
 2. select 'Deploy a branch' the default branch is `master` you'll normally want to retain this default
@@ -64,7 +76,7 @@ If this has worked you should see a modal dialogue asking for a username and pas
 
 If everything is working you should see a 'building app' message.
 
-## Configure automatic deploys
+### Configure automatic deploys
 
 Automatic deploys mean that every push to the `master` branch will deploy a new version of this app.
 
@@ -73,7 +85,7 @@ Automatic deploys mean that every push to the `master` branch will deploy a new 
 3. you'll see a dialogue asking you to choose a branch to deploy the default branch is `master` you'll normally want to retain this default
 4. click the 'Enable Automatic Deploys' button
 
-## Enable review apps
+### Enable review apps
 
 Review apps make it easy for your team to collaborate on design work by easily deploying pull requests. Meaning that the entire team can comment and review design work before you add it to your main prototype.
 

--- a/app/views/get-started/prototyping/README.md
+++ b/app/views/get-started/prototyping/README.md
@@ -1,10 +1,16 @@
 This guide explains how to create prototypes using the MOJ Design System and GOV.UK Prototype Kit.
 
-## Before you start
+## Use a template from Cloud Platform
 
-You must follow the [GOV.UK Design System prototype setup guide](https://design-system.service.gov.uk/get-started/prototyping/) first. Once you've done that, continue below.
+You can follow the [MOJ Cloud Platform guide](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/prototype-kit.html) to automatically set up a GitHub repository containing the GOV.UK Prototype Kit and a hosting environment.
 
-## Installing MOJ Frontend
+This template comes with the MOJ Design System pre-installed so you don't need to set it up manually. However you may need to update it using [the instructions below](#updating-moj-frontend).
+
+## Manual installation
+
+Alternatively, you can install the GOV.UK Prototype Kit and MOJ Design System manually. You must follow the [GOV.UK Design System prototype setup guide](https://design-system.service.gov.uk/get-started/prototyping/) first. Once you've done that, continue below.
+
+### Installing MOJ Frontend
 
 The MOJ Design System uses MOJ Frontend. To install it, run these steps:
 
@@ -15,14 +21,14 @@ The MOJ Design System uses MOJ Frontend. To install it, run these steps:
 
 ## Updating MOJ Frontend
 
-The current version of MOJ Frontend is **0.0.17-alpha**.
+The current version of MOJ Frontend is **0.2.1**.
 
 You can check which version your prototype is running by opening `package.json` in the root folder of your prototype. Look for `"@ministryofjustice/frontend"` under `"dependencies"`.
 
 To update your prototype to the latest version of MOJ Frontend:
 
 1. open `package.json` in the root folder of your prototype in a text editor
-2. Under `dependencies`, update the reference to MOJ Frontend to  `"@ministryofjustice/frontend": "0.0.17-alpha",`
+2. Under `dependencies`, update the reference to MOJ Frontend to `"@ministryofjustice/frontend": "0.2.1",`
 3. save `package.json`
 4. open Terminal/command line
 5. change the directory to your prototype's directory. For example, `cd path/to/prototype`


### PR DESCRIPTION
### Description of the change

Adds details of how to host prototypes on the MOJ Cloud Platform to both the "Prototyping" and "Deploying your prototype" documentation pages. Also pushes Heroku details down the hierarchy a little bit.

Cloud Platform is one of our strategic hosting platforms whereas Heroku is not, so we want to actively encourage users to use Cloud Platform. It also solves some recurrent issues of access, since Heroku dynos are typically created in free accounts and access is lost when the creator leaves the org.

I've added screenshots below of the fully-rendered pages after my changes.

![Captura de pantalla 2021-02-25 a las 11 06 48-fullpage](https://user-images.githubusercontent.com/100852/109144925-bb1d8200-7759-11eb-81ed-3c94a65c2ce8.png)
![Captura de pantalla 2021-02-25 a las 11 06 28-fullpage](https://user-images.githubusercontent.com/100852/109144832-9c1ef000-7759-11eb-85cb-607a0c89c9ab.png)


### Release notes

- Prototype documentation points to MOJ Cloud Platform as primary hosting platform