### PR TITLE
Rename default branch to main

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -8,7 +8,7 @@ about: Report a bug to help us improve the project
 
 Have you read the Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect:
 
-https://github.com/ministryofjustice/moj-design-system/blob/master/CODE_OF_CONDUCT.md
+https://github.com/ministryofjustice/moj-design-system/blob/main/CODE_OF_CONDUCT.md
 
 Do you want to ask a question? Are you looking for support? You can [contact the Design System team](https://moj-design-system.herokuapp.com/get-in-touch).
 

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -8,7 +8,7 @@ about: Suggest an idea for this project
 
 Have you read the Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect:
 
-https://github.com/ministryofjustice/moj-design-system/blob/master/CODE_OF_CONDUCT.md
+https://github.com/ministryofjustice/moj-design-system/blob/main/CODE_OF_CONDUCT.md
 
 Do you want to ask a question? Are you looking for support? You can [contact the Design System team](https://moj-design-system.herokuapp.com/get-in-touch).
 

--- a/.github/PULL_REQUEST_TEMPLATE/BUG_FIX.md
+++ b/.github/PULL_REQUEST_TEMPLATE/BUG_FIX.md
@@ -1,9 +1,9 @@
 ### Requirements for contributing a bug fix
 
 * Fill out the template below. Maintainers are free to close any pull requests that do not include enough information, at their discretion.
-* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at https://github.com/ministryofjustice/moj-design-system/tree/master/.github/PULL_REQUEST_TEMPLATE.
+* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at https://github.com/ministryofjustice/moj-design-system/tree/main/.github/PULL_REQUEST_TEMPLATE.
 * The pull request must update the test suite to demonstrate the changed functionality.
-* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see https://github.com/ministryofjustice/moj-design-system/tree/master/CONTRIBUTING.md#pull-requests.
+* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see https://github.com/ministryofjustice/moj-design-system/tree/main/CONTRIBUTING.md#pull-requests.
 
 ### Identify the bug
 

--- a/.github/PULL_REQUEST_TEMPLATE/DOCUMENTATION.md
+++ b/.github/PULL_REQUEST_TEMPLATE/DOCUMENTATION.md
@@ -1,7 +1,7 @@
 ### Requirements for contributing to documentation
 
 * Fill out the template below. Maintainers are free to close any pull requests that do not include enough information, at their discretion.
-* The pull request must only contribute documentation (for example, markdown files or API docs). To contribute other changes, you must use a different template. You can see all templates at https://github.com/ministryofjustice/moj-design-system/tree/master/.github/PULL_REQUEST_TEMPLATE.
+* The pull request must only contribute documentation (for example, markdown files or API docs). To contribute other changes, you must use a different template. You can see all templates at https://github.com/ministryofjustice/moj-design-system/tree/main/.github/PULL_REQUEST_TEMPLATE.
 
 ### Description of the change
 

--- a/.github/PULL_REQUEST_TEMPLATE/FEATURE_CHANGE.md
+++ b/.github/PULL_REQUEST_TEMPLATE/FEATURE_CHANGE.md
@@ -17,11 +17,11 @@ Link to the issue or RFC to which your change relates. This link must be one of 
 
 To contribute an enhancement that isn't covered by one of the items above, please follow our guide for suggesting an enhancement:
 
-https://github.com/ministryofjustice/moj-design-system/blob/master/CONTRIBUTING.md#suggesting-enhancements
+https://github.com/ministryofjustice/moj-design-system/blob/main/CONTRIBUTING.md#suggesting-enhancements
 
 To contribute other changes, you must use a different template. You can see all templates at:
 
-https://github.com/ministryofjustice/moj-design-system/tree/master/.github/PULL_REQUEST_TEMPLATE.
+https://github.com/ministryofjustice/moj-design-system/tree/main/.github/PULL_REQUEST_TEMPLATE.
 
 -->
 

--- a/.github/PULL_REQUEST_TEMPLATE/PERFORMANCE_IMPROVEMENT.md
+++ b/.github/PULL_REQUEST_TEMPLATE/PERFORMANCE_IMPROVEMENT.md
@@ -1,8 +1,8 @@
 ### Requirements for contributing a performance improvement
 
 * Fill out the template below. Maintainers are free to close any pull requests that do not include enough information, at their discretion.
-* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at https://github.com/ministryofjustice/moj-design-system/tree/master/.github/PULL_REQUEST_TEMPLATE.
-* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see https://github.com/ministryofjustice/moj-design-system/tree/master/CONTRIBUTING.md#pull-requests.
+* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at https://github.com/ministryofjustice/moj-design-system/tree/main/.github/PULL_REQUEST_TEMPLATE.
+* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see https://github.com/ministryofjustice/moj-design-system/tree/main/CONTRIBUTING.md#pull-requests.
 
 ### Description of the change
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,7 +2,7 @@ name: Build service on pull request
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 When contributing to this repository, please first discuss the change you wish to make via issue, email, or any other method with the owners of this repository before making a change.
 
-Please note we have a [code of conduct](https://github.com/ministryofjustice/mojdt-design-system/blob/master/CODE_OF_CONDUCT.md), please follow it in all your interactions with the project.
+Please note we have a [code of conduct](https://github.com/ministryofjustice/moj-design-system/blob/main/CODE_OF_CONDUCT.md), please follow it in all your interactions with the project.
 
 ## Contributing
 
@@ -23,7 +23,7 @@ When describing the bug, it's useful to follow the format:
 
 ## Suggesting features
 
-Please [raise feature requests as issues](https://github.com/ministryofjustice/mojdt-design-system/issues) before contributing any code.
+Please [raise feature requests as issues](https://github.com/ministryofjustice/moj-design-system/issues) before contributing any code.
 
 Raising an issue ensures they are openly discussed and before spending any time on them.
 
@@ -41,4 +41,4 @@ Change versions in a commit of their own, in a pull request of their own. This c
 - Use the imperative mood ("Move thing to..." not "Moves thing to...")
 - Limit the first line to 72 characters or less
 - Reference issues and pull requests liberally after the first line
-- Use a [pull request template](https://github.com/ministryofjustice/mojdt-design-system/blob/master/.github/PULL_REQUEST_TEMPLATE)
+- Use a [pull request template](https://github.com/ministryofjustice/moj-design-system/blob/main/.github/PULL_REQUEST_TEMPLATE)

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -3,10 +3,10 @@
 Please follow the steps below to tell us about your contribution.
 
 1. Copy the correct template for your contribution
-  - Are you fixing a bug? [Copy the template](https://github.com/ministryofjustice/mojdt-design-system/tree/master/.github/PULL_REQUEST_TEMPLATE/BUG_FIX.md)
-  - Are you improving performance? [Copy the template](https://github.com/ministryofjustice/mojdt-design-system/tree/master/.github/PULL_REQUEST_TEMPLATE/PERFORMANCE_IMPROVEMENT.md)
-  - Are you updating documentation? [Copy the template](https://github.com/ministryofjustice/mojdt-design-system/tree/master/.github/PULL_REQUEST_TEMPLATE/DOCUMENTATION.md)
-  - Are you changing functionality? [Copy the template](https://github.com/ministryofjustice/mojdt-design-system/tree/master/.github/PULL_REQUEST_TEMPLATE/FEATURE_CHANGE.md)
+  - Are you fixing a bug? [Copy the template](https://github.com/ministryofjustice/moj-design-system/tree/main/.github/PULL_REQUEST_TEMPLATE/BUG_FIX.md)
+  - Are you improving performance? [Copy the template](https://github.com/ministryofjustice/moj-design-system/tree/main/.github/PULL_REQUEST_TEMPLATE/PERFORMANCE_IMPROVEMENT.md)
+  - Are you updating documentation? [Copy the template](https://github.com/ministryofjustice/moj-design-system/tree/main/.github/PULL_REQUEST_TEMPLATE/DOCUMENTATION.md)
+  - Are you changing functionality? [Copy the template](https://github.com/ministryofjustice/moj-design-system/tree/main/.github/PULL_REQUEST_TEMPLATE/FEATURE_CHANGE.md)
 2. Replace this text with the contents of the template
 3. Fill in all sections of the template
 4. Click "Create pull request".

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ Create a folder called `Projects` in your `Documents` folder.
 
 #### Unzip the design system and move it
 
-Unzip the design system you downloaded - you should end up with a folder called `mojdt-design-system-master`.
+Unzip the design system you downloaded - you should end up with a folder called `moj-design-system-main`.
 
-Rename the folder to something descriptive for your local version. For this guide, we’ll use `mojdt-design-system`.
+Rename the folder to something descriptive for your local version. For this guide, we’ll use `moj-design-system`.
 
 Move the folder into your `Projects` folder.
 
@@ -99,18 +99,18 @@ Learning a few basic terminal commands can make using the kit much easier.
 
 #### Navigating to your local instance
 
-You need to navigate to your local instance in the terminal. Most commands for the kit need to be run in the mojdt-design-system folder.
+You need to navigate to your local instance in the terminal. Most commands for the kit need to be run in the moj-design-system folder.
 
 **Mac users:**
 
 ```
-cd ~/Projects/mojdt-design-system
+cd ~/Projects/moj-design-system
 ```
 
 **Windows users:**
 
 ```
-cd ~/Documents/Projects/mojdt-design-system
+cd ~/Documents/Projects/moj-design-system
 ```
 
 ### Install the kit
@@ -147,14 +147,14 @@ _NB. if port 3000 is already in use, the design system will try and find the nex
 This repository is maintained by a team at the Ministry of Justice. If you’ve got a question or need support you can:
 
 - Email design-system@digital.justice.gov.uk.
-- [View known issues on GitHub](https://github.com/ministryofjustice/mojdt-design-system/issues).
+- [View known issues on GitHub](https://github.com/ministryofjustice/moj-design-system/issues).
 
 ## Contributing
 If you’ve got an idea or suggestion you can:
 
 - Email design-system@digital.justice.gov.uk.
-- [Create a GitHub issue](https://github.com/ministryofjustice/mojdt-design-system/issues).
+- [Create a GitHub issue](https://github.com/ministryofjustice/moj-design-system/issues).
 
 ## Licence
 
-Unless otherwise stated, this codebase is released under the [MIT License](https://github.com/ministryofjustice/mojdt-design-system/blob/master/LICENSE). This covers both the codebase and any sample code in the documentation.
+Unless otherwise stated, this codebase is released under the [MIT License](https://github.com/ministryofjustice/moj-design-system/blob/main/LICENSE). This covers both the codebase and any sample code in the documentation.

--- a/app.json
+++ b/app.json
@@ -1,5 +1,5 @@
 {
-  "name": "mojdt-design-system",
+  "name": "moj-design-system",
   "description": "The MOJ Design System is one place for service teams to find styles, components and patterns for designing Ministry of Justice services.",
   "keywords": [
     "ministry-of-justice",
@@ -9,7 +9,7 @@
     "patterns"
   ],
   "website": "https://moj-design-system.herokuapp.com/",
-  "repository": "https://github.com/ministryofjustice/mojdt-design-system",
+  "repository": "https://github.com/ministryofjustice/moj-design-system",
   "addons": [
 
   ],

--- a/app/components/nav/README.md
+++ b/app/components/nav/README.md
@@ -101,4 +101,4 @@ This component accepts the following arguments.
 
 ## Licence
 
-Unless otherwise stated, this codebase is released under the [MIT License](https://github.com/whatterz/moj-design-system/blob/master/LICENSE). This covers both the codebase and any sample code in the documentation.
+Unless otherwise stated, this codebase is released under the [MIT License](https://github.com/ministryofjustice/moj-design-system/blob/main/LICENSE). This covers both the codebase and any sample code in the documentation.

--- a/app/components/panel/README.md
+++ b/app/components/panel/README.md
@@ -53,4 +53,4 @@ This component accepts the following arguments.
 
 ## Licence
 
-Unless otherwise stated, this codebase is released under the [MIT License](https://github.com/ministryofjustice/mojdt-design-system/blob/master/LICENSE). This covers both the codebase and any sample code in the documentation.
+Unless otherwise stated, this codebase is released under the [MIT License](https://github.com/ministryofjustice/moj-design-system/blob/main/LICENSE). This covers both the codebase and any sample code in the documentation.

--- a/app/components/subnav/README.md
+++ b/app/components/subnav/README.md
@@ -126,4 +126,4 @@ This component accepts the following arguments.
 
 ## Licence
 
-Unless otherwise stated, this codebase is released under the [MIT License](https://github.com/whatterz/moj-design-system/blob/master/LICENSE). This covers both the codebase and any sample code in the documentation.
+Unless otherwise stated, this codebase is released under the [MIT License](https://github.com/ministryofjustice/moj-design-system/blob/main/LICENSE). This covers both the codebase and any sample code in the documentation.

--- a/app/views/community/backlog/README.md
+++ b/app/views/community/backlog/README.md
@@ -8,7 +8,7 @@ The [community backlog](https://github.com/ministryofjustice/moj-design-system-b
 - **To do** – the proposed component or pattern has been agreed and is ready to work on
 - **In progress** – someone is actively working on the component or pattern
 
-You can discuss the existing styles, components and patterns in the Design System, or ones being developed, by commenting on issues in the [community backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/projects/1). 
+You can discuss the existing styles, components and patterns in the Design System, or ones being developed, by commenting on issues in the [community backlog](https://github.com/ministryofjustice/moj-design-system-backlog/projects/1).
 
 For example, you can:
 

--- a/app/views/community/propose-a-component-or-pattern/README.md
+++ b/app/views/community/propose-a-component-or-pattern/README.md
@@ -19,14 +19,14 @@ At this stage, you just need to present your idea and evidence of the user needs
 
 ## 3. Send your proposal for review
 
-The Design System team will help you prepare your proposal and share it with the [Design System working group](https://moj-design-system.herokuapp.com/community/design-system-working-group) to review. 
+The Design System team will help you prepare your proposal and share it with the [Design System working group](https://moj-design-system.herokuapp.com/community/design-system-working-group) to review.
 
-When your proposal is ready, the Design System team will send it to the working group one week before their next monthly meeting. 
+When your proposal is ready, the Design System team will send it to the working group one week before their next monthly meeting.
 
 At the meeting, the working group will review your proposal and decide if it is useful and unique. This review helps people avoid spending time and effort on something that's not needed for the design system.
 
-After the meeting, the Design System team will let you know the decision and recommendations, if there are any. 
+After the meeting, the Design System team will let you know the decision and recommendations, if there are any.
 
-If the working group agrees your proposal is useful and unique, the working group will mark it as 'to do' on the [community backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/projects/1).
+If the working group agrees your proposal is useful and unique, the working group will mark it as 'to do' on the [community backlog](https://github.com/ministryofjustice/moj-design-system-backlog/projects/1).
 
 At this point, you can either start to develop the component or pattern or leave it for someone else to work on.


### PR DESCRIPTION
Also, fix some references to old repositories.

There are still references to the master branch of `moj-frontend` as that has not yet been renamed.

Fixes #57