### PR TITLE
Update links to moj-frontend default branch

### DIFF
--- a/app/components/example/template.njk
+++ b/app/components/example/template.njk
@@ -22,7 +22,7 @@
 {% set exampleHref = '/' + section + params.name + '/examples/' + params.example %}
 
 {%- if section == 'components/' %}
-  {% set argumentsHref = 'https://github.com/ministryofjustice/moj-frontend/tree/master/src/moj/' + section + params.name + '#arguments' %}
+  {% set argumentsHref = 'https://github.com/ministryofjustice/moj-frontend/tree/main/src/moj/' + section + params.name + '#arguments' %}
 {% endif -%}
 
 {%- set nunjucksCode %}

--- a/app/views/community/contribution-criteria/README.md
+++ b/app/views/community/contribution-criteria/README.md
@@ -81,7 +81,7 @@ The working group reviews the implementation to make sure it is usable, consiste
 
         <p>Both the guidance and any content included in examples must follow the <a href='https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style'>GOV.UK content style guide</a>.</p>
 
-        <p class='govuk-!-margin-bottom-0'>If there is code, it follows the <a href='https://github.com/ministryofjustice/moj-frontend/blob/master/CONTRIBUTING.md#conventions-to-follow'>MOJ Frontend coding standards</a> and is ready to merge in <a href='https://www.npmjs.com/package/@ministryofjustice/frontend'>MOJ Frontend</a>.</p>"
+        <p class='govuk-!-margin-bottom-0'>If there is code, it follows the <a href='https://github.com/ministryofjustice/moj-frontend/blob/main/CONTRIBUTING.md#conventions-to-follow'>MOJ Frontend coding standards</a> and is ready to merge in <a href='https://www.npmjs.com/package/@ministryofjustice/frontend'>MOJ Frontend</a>.</p>"
       }
     ],
     [

--- a/app/views/get-started/production/README.md
+++ b/app/views/get-started/production/README.md
@@ -8,7 +8,7 @@ First you must have followed the [GOV.UK Design System production setup guide](h
 
 To start using MOJ styles, components and patterns contained here, you’ll need to include MOJ Frontend in your project.
 
-We recommend [installing MOJ Frontend using npm](https://github.com/ministryofjustice/moj-frontend/blob/master/docs/installation/installing-with-npm.md). Using this option, you will be able to:
+We recommend [installing MOJ Frontend using npm](https://github.com/ministryofjustice/moj-frontend/blob/main/docs/installation/installing-with-npm.md). Using this option, you will be able to:
 
 - selectively include the CSS or JavaScript for individual components
 - build your own styles or components based on the palette or typography and spacing mixins


### PR DESCRIPTION
The moj-frontend default branch has been renamed to `main`. This updates the direct links in this repo so that they still take people to the right place.