### PR TITLE
Add deprecation notice

### DIFF
--- a/app/views/layouts/guidance.html
+++ b/app/views/layouts/guidance.html
@@ -6,9 +6,9 @@
 
     {% include "./partials/header.html" %}
 
-    {% include "./partials/phase-banner.html" %}
-
     {% include "./partials/navigation.html" %}
+
+    {% include "./partials/deprecation-notice.html" %}
 
     <div class="app-pane__body">
 

--- a/app/views/layouts/landing.html
+++ b/app/views/layouts/landing.html
@@ -6,9 +6,9 @@
 
     {% include "./partials/header.html" %}
 
-    {% include "./partials/phase-banner.html" %}
-
     {% include "./partials/navigation.html" %}
+
+    {% include "./partials/deprecation-notice.html" %}
 
     <div class="app-pane__content">
 

--- a/app/views/layouts/partials/deprecation-notice.html
+++ b/app/views/layouts/partials/deprecation-notice.html
@@ -1,0 +1,16 @@
+{% set html %}
+  <h3 class="govuk-notification-banner__heading">
+    The MOJ Design System has moved
+  </h3>
+  <p class="govuk-body">You can now find the MOJ Pattern Library at <a href="https://design-patterns.service.justice.gov.uk">design-patterns.service.justice.gov.uk</a>.</p>
+
+  <p class="govuk-body">Use the MOJ Pattern Library for the latest documentation, or if you want to contribute research findings, designs or code.</p>
+
+  <p class="govuk-body">If you’re already using MOJ components and patterns in your project, you do not need to make any changes to your installation.</p>
+{% endset %}
+
+<div class="govuk-width-container govuk-!-margin-top-6 govuk-!-margin-bottom-6">
+  {{ govukNotificationBanner({
+    html: html
+  }) }}
+</div>


### PR DESCRIPTION
Adds a deprecation notice to clarify that documentation has been moved to the MOJ Pattern Library.

In September we will replace this old documentation with redirects to the new pages.

<img width="1679" alt="imagen" src="https://user-images.githubusercontent.com/100852/125485530-949f04f5-b75a-4847-8ade-e261587e95b0.png">
